### PR TITLE
Add profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 __pycache__
 predictions
 *.pt
+wandb
+.vscode
+log

--- a/multitask_classifier.py
+++ b/multitask_classifier.py
@@ -211,6 +211,7 @@ class Trainer:
                 with torch.profiler.profile(
                         schedule=torch.profiler.schedule(wait=1, warmup=1, active=3, repeat=1),
                         activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                        # Comment out the following line to generate trace.json, which can be viewed in chrome://tracing
                         on_trace_ready=torch.profiler.tensorboard_trace_handler('./log/minbert'),
                         record_shapes=True,
                         profile_memory=True,
@@ -223,7 +224,8 @@ class Trainer:
                 print(prof.key_averages(group_by_input_shape=True).table(sort_by="cpu_time_total", row_limit=10))
                 print(">"*20 + "CUDA Profile" + "<"*20)
                 print(prof.key_averages().table(sort_by="cuda_time_total", row_limit=10))
-                prof.export_chrome_trace("trace.json")
+                # Uncomment the following line to export the trace for chrome/edge
+                # prof.export_chrome_trace("trace.json")
 
                 return
 

--- a/multitask_classifier.py
+++ b/multitask_classifier.py
@@ -165,9 +165,9 @@ class Trainer:
 
                 # hardcode 5 as profiling steps
                 if prof is not None and steps > 5:
-                    break
+                    return num_batches
             except StopIteration:
-                break
+                return num_batches
 
     def train(self, device: str):
         for task in self.tasks:
@@ -217,7 +217,7 @@ class Trainer:
                         profile_memory=True,
                         with_stack=True
                 ) as prof:
-                        self._loop(train_iter, device, optimizer, train_loss,
+                        num_batches = self._loop(train_iter, device, optimizer, train_loss,
                        num_batches, progress_bar, tasks_tilde, epoch, prof)
                         
                 print(">"*20 + "CPU Profile" + "<"*20)
@@ -230,7 +230,7 @@ class Trainer:
                 return
 
             else:
-                self._loop(train_iter, device, optimizer, train_loss,
+                num_batches = self._loop(train_iter, device, optimizer, train_loss,
                         num_batches, progress_bar, tasks_tilde, epoch)
 
             progress_bar.close()


### PR DESCRIPTION
Adds profiling

* When `--profile` is passed in, the training loop will only run for 5 steps
    * Example command to invoke: ``python multitask_classifier.py --option finetune --lr 1e-5 --use_gpu --tasks sst quora --epochs 2 --profile``
* Pytorch profile is used to generate trace file, once profiling finishes, one can do `tensorboard --logdir=./log` to launch tensorboard to look at the result
* Some findings:
    * The most time consuming operator is `autograd::engine::evaluate_function: AddmmBackward0`, so I suppose that's why flash attention had limited help
 

<img width="1627" alt="image" src="https://github.com/Luismorlan/minbert/assets/7604668/6d8ddcf4-6f4e-427f-8f95-80125e545d3a">

 